### PR TITLE
[ADD] Direction to Selected Point of Interest

### DIFF
--- a/frontend/src/pages/Campus.tsx
+++ b/frontend/src/pages/Campus.tsx
@@ -6,6 +6,7 @@ import ToggleCampus from "../components/ToggleCampusComponent";
 import { FaStar } from "react-icons/fa";
 import ModalPOI from "../components/ModalPOI";
 import BuildingMarkers from "../components/BuildingMarkers";
+import { useNavigate } from "react-router-dom"; // Import useNavigate
 
 type CampusType = 'SGW' | 'LOYOLA'; // Define a type for campus to ensure only these two values are valid
 
@@ -32,7 +33,8 @@ function CampusMap() {
     const [isModalOpen, setIsModalOpen] = useState(false); // Modal visibility
     const [center, setCenter] = useState(CAMPUS_COORDINATES.SGW);
     const [showBuildings, setShowBuildings] = useState(false); // Visibility of building markers
-
+    const [destination, setDestination] = useState<string>(""); // Store the destination address
+    const navigate = useNavigate(); 
 
     useEffect(() => {
         fetch("/Building.geojson")
@@ -266,6 +268,15 @@ function CampusMap() {
                                             style={{ width: '100%', height: 'auto', borderRadius: '5px' }}
                                         />
                                     )}
+                                    <button
+                                    style={{ marginTop: '10px', padding: '5px 10px', fontSize: '14px', backgroundColor: '#007bff', color: 'white', border: 'none', borderRadius: '5px' }}
+                                    onClick={() => {
+                                        setDestination(selectedPoi.vicinity); //Set the destination adress
+                                        navigate('/directions', { state: { destination: selectedPoi.vicinity + ' ' } }); // Navigate to directions page with destination address
+                                    }}
+                                >
+                                    Get Directions
+                                </button>
                                 </div>
                             </InfoWindow>
                         )}

--- a/frontend/src/pages/Directions.tsx
+++ b/frontend/src/pages/Directions.tsx
@@ -1,4 +1,5 @@
 import React, { useState, useRef, useEffect, useContext } from 'react';
+import { useLocation } from 'react-router-dom'; 
 import MyLocationIcon from '@mui/icons-material/MyLocation';
 import RoomIcon from '@mui/icons-material/Room';
 import { getSuggestions, getPlaceDetails } from '../services/PlaceServices';
@@ -19,9 +20,11 @@ interface LocationType {
 }
 
 const Directions = () => {
+    const location = useLocation(); //useLocation to get the state
+    const destinationFromState = location.state?.destination || ""; // Get destination from state
     const [active, setActive] = useState<string>("");
     const [sourceQuery, setSourceQuery] = useState<string>("");
-    const [destinationQuery, setDestinationQuery] = useState<string>("");
+    const [destinationQuery, setDestinationQuery] = useState<string>(destinationFromState);
     const [sourceResults, setSourceResults] = useState<LocationType[]>([]);
     const [destinationResults, setDestinationResults] = useState<LocationType[]>([]);
     const [transportationMode, setTransportationMode] = useState<"driving" | "transit" | "walking" | "bicycling">("driving");
@@ -93,6 +96,17 @@ const Directions = () => {
         }
     }, [userLocation, isResettingStart, isUserTyping]);
 
+    useEffect(() => {
+        if (destinationFromState) {
+            setDestinationQuery(destinationFromState); // Set destination query
+            //poi details for the destination address
+            getPlaceDetails(destinationFromState).then((placeDetails) => {
+                setDestination(placeDetails as LocationType);
+            }).catch((error) => {
+                console.error("Error fetching place details:", error);
+            });
+        }
+    }, [destinationFromState]);
 
     // No longer need the useEffect for fetching suggestions.  It's handled by handleDebouncedSuggestions
 
@@ -275,10 +289,10 @@ const Directions = () => {
                         }
                     </div>
 
-                   {(active === "start" ? sourceResults : destinationResults).length > 0 && (
+                   {(active === "start" ? sourceResults : destinationResults)?.length > 0 && (
                         <div className="flex w-full">
                             <ul className="w-full" id="suggestions-container">
-                                {(active === "start" ? sourceResults : destinationResults).map((result, index) => (
+                                {(active === "start" ? sourceResults : destinationResults)?.map((result, index) => (
                                     <li key={index}
                                         id="suggestion-item-container"
                                         onKeyDown={(e) => e.key === "Enter" && handleSelect(index)}
@@ -300,7 +314,7 @@ const Directions = () => {
                         </div>
                     )}
 
-                      {(active === "start" ? sourceResults : destinationResults).length === 0 && (
+                      {(active === "start" ? sourceResults : destinationResults)?.length === 0 && (
                         <div id='directions-request-container' className="flex flex-col items-center w-full">
                             <button
                                 id="get-directions-button"


### PR DESCRIPTION
## Title
Implement Directions to Outdoor Points of Interest (US-22)

## Type of Changes
- [ ] New feature
- [ ] Bug fix 
- [ ] CI/CD Update
- [ ] UI/UX Improvement 
- [ ] Refactoring 

## Description 
This PR introduces the feature that allows users to get directions to a selected point of interest outside the campus. When a user selects a nearby point of interest and clicks "Get Directions," the app retrieves and displays the route to the selected location.

User selects point of interest and clicks "Get Directions"
![image](https://github.com/user-attachments/assets/ac61e55d-1f48-4f02-9f0a-85bd68dd02b9)

POI address directly stored and sent to destination prompt in Outdoor Directions
![image](https://github.com/user-attachments/assets/d1469583-3ed6-4b09-a39f-e9f2104ef1d0)


## Description of the bug [if not aapplicable remove]:
[describe the bug that was present]


## describe the resolved behaviour [if not applicable remove]
[describe the modified/resolved behaviour]


<i> <b> Related issues # (issue)  
closes #127 
closes #128 
</b> </i>

## Additional Information
[Any additional information that reviewers should be aware of.]

## Added tests ?

- [ ] ✅ Yes.
- [ ] ❌ No cause they aren't necessary.

## Checklist 

- [ ] I have commented my code.
- [ ] I have performed a self-review of my code


