### PR TITLE
[BUG FIX] directions displayed before selecting a route

### DIFF
--- a/backend/src/services/maps_services/directionsService.ts
+++ b/backend/src/services/maps_services/directionsService.ts
@@ -74,11 +74,6 @@ export const fetchDirections = async (source: string, destination: string) => {
                 console.log('Error getting transit directions');
                 return null;
             }else{
-                // console.log("transit: " ,response.data.routes[0].legs[0].steps[1].transit_details);
-                
-                // if(response.data.routes.length > 3){ //if there are more than 3 routes, only return the first 3 because the response is too big
-                //     response.data.routes = response.data.routes.slice(0,3);
-                // }
                 orderRoutes(response); //function to order the routes by duration
                 return response;
             }
@@ -101,7 +96,6 @@ export const fetchDirections = async (source: string, destination: string) => {
             },
         };
 
-        // console.log("response from fetchDirections:" ,response.data);
         return response.data;
     } catch (error) {
         console.error('Error getting directions:', error);

--- a/backend/src/services/maps_services/directionsService.ts
+++ b/backend/src/services/maps_services/directionsService.ts
@@ -1,98 +1,51 @@
+
 import axios from 'axios';
 import { orderRoutes } from '../../utils/orderRoutes.js';
+import { trimRoutes } from '../../utils/trimRoutes.js';
+
+const fetchDirectionsForMode = async (source: string, destination: string, mode: string) => {
+    try {
+        const response = await axios.get('https://maps.googleapis.com/maps/api/directions/json', {
+            params: {
+                origin: `place_id:${source}`,
+                destination: `place_id:${destination}`,
+                mode,
+                key: process.env.GOOGLE_MAPS_API_KEY,
+                alternatives: true,
+            },
+        });
+
+        if (response.data.status !== 'OK') {
+            console.error(`No available ${mode} directions`);
+            return null;
+        } else {
+            orderRoutes(response); // Function to order the routes by duration
+            return response;
+        }
+    } catch (error) {
+        console.error(`Error getting ${mode} directions:`, error);
+        return null;
+    }
+};
 
 export const fetchDirections = async (source: string, destination: string) => {
-
     try {
-        let responseDriving = await axios.get('https://maps.googleapis.com/maps/api/directions/json', {
-            params: {
-                origin: `place_id:${source}`,
-                destination: `place_id:${destination}`,
-                mode: 'driving',
-                key: process.env.GOOGLE_MAPS_API_KEY,
-                alternatives: true,
-            },
-        }).then((response) => {
-            if(response.data.status !== 'OK'){
-                console.error('No available driving directions');
-                return null;
-            }else{
-                orderRoutes(response); //function to order the routes by duration
-                return response;
-            }
-        });
-      
+        const responseDriving = await fetchDirectionsForMode(source, destination, 'driving');
+        const responseWalking = await fetchDirectionsForMode(source, destination, 'walking');
+        const responseBicycling = await fetchDirectionsForMode(source, destination, 'bicycling');
+        const responseTransit = await fetchDirectionsForMode(source, destination, 'transit');
 
-        const responseWalking = await axios.get('https://maps.googleapis.com/maps/api/directions/json', {
-            params: {
-                origin: `place_id:${source}`,
-                destination: `place_id:${destination}`,
-                mode: 'walking',
-                key: process.env.GOOGLE_MAPS_API_KEY,
-                alternatives: true,
-            },
-        }).then((response) => {
-            if (response.data.status !== 'OK'){
-                console.error('No available walking directions');
-                return null;
-            }else{
-                orderRoutes(response); //function to order the routes by duration
-                return response;
-            }
-        });
-
-
-        const responseBicycling = await axios.get('https://maps.googleapis.com/maps/api/directions/json', {
-            params: {
-                origin: `place_id:${source}`,
-                destination: `place_id:${destination}`,
-                mode: 'bicycling',
-                key: process.env.GOOGLE_MAPS_API_KEY,
-                alternatives: true,
-            },
-        }).then((response) => {
-            if (response.data.status !== 'OK'){
-                console.error('No available bicycling directions');
-                return null;
-            }else{
-                orderRoutes(response); //function to order the routes by duration
-                return response;
-            }
-        });
-         
-       
-        const responseTransit = await axios.get('https://maps.googleapis.com/maps/api/directions/json', {
-            params: {
-                origin: `place_id:${source}`,
-                destination: `place_id:${destination}`,
-                mode: 'transit',
-                key: process.env.GOOGLE_MAPS_API_KEY,
-                alternatives: true,
-            },
-        }).then((response) => {
-            if (response.data.status !== 'OK'){
-                console.log('Error getting transit directions');
-                return null;
-            }else{
-                orderRoutes(response); //function to order the routes by duration
-                return response;
-            }
-        });
-
-        //if all were null, throw an error
+        // If all were null, throw an error
         if (!responseDriving && !responseWalking && !responseBicycling && !responseTransit) {
             throw new Error('Error getting directions');
         }
-
-
+        
         const response = {
-
-            //if the response is null just return an empty array otherwise return the routes
             data: {
-                walking: responseWalking? responseWalking.data.routes : [],
-                driving: responseDriving? responseDriving.data.routes.slice(0,3) : [],
+                walking: responseWalking ? responseWalking.data.routes : [],
+                driving: responseDriving ? responseDriving.data.routes : [],
                 bicycling: responseBicycling ? responseBicycling.data.routes : [],
-                transit: responseTransit ? (responseTransit.data.routes.length > 3 ? responseTransit.data.routes.slice(0,3): responseTransit.data.routes) : [],
+                transit: responseTransit ?  trimRoutes(responseTransit) : [],
             },
         };
 
@@ -101,4 +54,4 @@ export const fetchDirections = async (source: string, destination: string) => {
         console.error('Error getting directions:', error);
         throw new Error('Error getting directions');
     }
-}
+};

--- a/backend/src/services/maps_services/directionsService.ts
+++ b/backend/src/services/maps_services/directionsService.ts
@@ -74,11 +74,11 @@ export const fetchDirections = async (source: string, destination: string) => {
                 console.log('Error getting transit directions');
                 return null;
             }else{
-                console.log("transit: " ,response.data.routes[0].legs[0].steps[1].transit_details);
+                // console.log("transit: " ,response.data.routes[0].legs[0].steps[1].transit_details);
                 
-                if(response.data.routes.length > 3){ //if there are more than 3 routes, only return the first 3 because the response is too big
-                    response.data.routes = response.data.routes.slice(0,3);
-                }
+                // if(response.data.routes.length > 3){ //if there are more than 3 routes, only return the first 3 because the response is too big
+                //     response.data.routes = response.data.routes.slice(0,3);
+                // }
                 orderRoutes(response); //function to order the routes by duration
                 return response;
             }
@@ -88,14 +88,16 @@ export const fetchDirections = async (source: string, destination: string) => {
         if (!responseDriving && !responseWalking && !responseBicycling && !responseTransit) {
             throw new Error('Error getting directions');
         }
+
+
         const response = {
 
             //if the response is null just return an empty array otherwise return the routes
             data: {
                 walking: responseWalking? responseWalking.data.routes : [],
-                driving: responseDriving? responseDriving.data.routes : [],
+                driving: responseDriving? responseDriving.data.routes.slice(0,3) : [],
                 bicycling: responseBicycling ? responseBicycling.data.routes : [],
-                transit: responseTransit ? responseTransit.data.routes : [],
+                transit: responseTransit ? (responseTransit.data.routes.length > 3 ? responseTransit.data.routes.slice(0,3): responseTransit.data.routes) : [],
             },
         };
 

--- a/backend/src/services/maps_services/directionsService.ts
+++ b/backend/src/services/maps_services/directionsService.ts
@@ -71,9 +71,14 @@ export const fetchDirections = async (source: string, destination: string) => {
             },
         }).then((response) => {
             if (response.data.status !== 'OK'){
-                console.error('Error getting transit directions');
+                console.log('Error getting transit directions');
                 return null;
             }else{
+                console.log("transit: " ,response.data.routes[0].legs[0].steps[1].transit_details);
+                
+                if(response.data.routes.length > 3){ //if there are more than 3 routes, only return the first 3 because the response is too big
+                    response.data.routes = response.data.routes.slice(0,3);
+                }
                 orderRoutes(response); //function to order the routes by duration
                 return response;
             }
@@ -94,7 +99,7 @@ export const fetchDirections = async (source: string, destination: string) => {
             },
         };
 
-        console.log("response from fetchDirections:" ,response.data);
+        // console.log("response from fetchDirections:" ,response.data);
         return response.data;
     } catch (error) {
         console.error('Error getting directions:', error);

--- a/backend/src/tests/routes/mapRoutes.test.ts
+++ b/backend/src/tests/routes/mapRoutes.test.ts
@@ -231,8 +231,8 @@ describe("GET /maps/directions", () => {
   });
 
   it("should return route directions", async () => {
-    const source = "ChIJN1t_tDeuEmsRUsoyG83frY4"; // Example Place ID
-    const destination = "ChIJsXU6z5lZwokRdsjKc_UGGWA"; // Example Place ID
+    const source = "ChIJDbdkHFQayUwR7-8fITgxTmU"; // Example Place ID
+    const destination = "ChIJ-XRliGkbyUwRLtoWc4pDYxw"; // Example Place ID
 
     // Mock the API response
     mock.onGet("https://maps.googleapis.com/maps/api/directions/json").reply(200, {
@@ -261,6 +261,10 @@ describe("GET /maps/directions", () => {
     const response = await request(app)
       .get("/maps/directions")
       .query({ source, destination });
+      if (response.status !== 200) {
+        console.error('Error response:', response.body);
+      }
+  
 
     expect(response.status).toBe(200);
     expect(response.body).toEqual(

--- a/backend/src/tests/routes/mapRoutes.test.ts
+++ b/backend/src/tests/routes/mapRoutes.test.ts
@@ -1,4 +1,4 @@
-import express, { query } from 'express';
+import express from 'express';
 import mapRoutes from '../../routes/mapRoutes.js';
 import { describe, test, expect, it, beforeEach } from 'vitest';
 import request from 'supertest';
@@ -31,7 +31,6 @@ describe('GET /maps/addressFromCoordinates', () => {
   });
 
   it('should return formatted_address and place_id', async () => {
-    const latlng = '45.5049,-73.5779';
 
     mock.onGet('https://maps.googleapis.com/maps/api/geocode/json').reply(200, {
       status: 'OK',

--- a/backend/src/tests/utils/trimRoutes.test.ts
+++ b/backend/src/tests/utils/trimRoutes.test.ts
@@ -1,0 +1,36 @@
+import {describe, expect, test} from 'vitest';
+import {trimRoutes} from '../../utils/trimRoutes.js';
+
+describe('trimRoutes() function', () => {
+    test("should return an array of 3 routes for arrays that are too long", () => {
+        const directions = {
+            data: {
+                routes: [
+                    {duration: 100},
+                    {duration: 200},
+                    {duration: 300},
+                    {duration: 400},
+                    {duration: 500},
+                ],
+            },
+        }
+
+        const result = trimRoutes(directions);
+        expect(result).toHaveLength(3);
+
+    });
+    test('should return the same array for arrays that are already of length <= 3', () => {
+        const directions = {
+            data: {
+                routes: [
+                    {duration: 100},
+                    {duration: 200},
+                    {duration: 300},
+                ],
+            },
+        }
+
+        const result = trimRoutes(directions);
+        expect(result).toEqual(directions.data.routes);
+    });
+});

--- a/backend/src/utils/trimRoutes.ts
+++ b/backend/src/utils/trimRoutes.ts
@@ -1,0 +1,8 @@
+export function trimRoutes(directionsResponse:any):any{
+    if (directionsResponse.data.routes.length > 3) {
+        return directionsResponse.data.routes.slice(0, 3);
+    }
+    else {
+        return directionsResponse.data.routes;
+    }
+}

--- a/frontend/src/components/RouteRenderer.tsx
+++ b/frontend/src/components/RouteRenderer.tsx
@@ -1,0 +1,74 @@
+import { useMap, useMapsLibrary } from '@vis.gl/react-google-maps';
+import { useEffect, useState } from "react";
+
+interface LocationType {
+    name: string;
+    address: string;
+    place_id: string;
+    lat: number;
+    lng: number;
+}
+
+
+function RouteRenderer({ source, destination, selectedRouteIndex, transportationMode }: {
+    source: LocationType | undefined;
+    destination: LocationType | undefined;
+    selectedRouteIndex: number;
+    transportationMode: "driving" | "transit" | "walking" | "bicycling";
+
+}) {
+    const map = useMap();
+    const routesLibrary = useMapsLibrary('routes');
+    const [directionsService, setDirectionsService] = useState<google.maps.DirectionsService>();
+    const [directionsRenderer, setDirectionsRenderer] = useState<google.maps.DirectionsRenderer>();
+    const [displayedRoute, setDisplayedRoute] = useState<google.maps.DirectionsResult | null>(null);
+
+    useEffect(() => {
+        if (!routesLibrary || !map) return;
+        setDirectionsService(new google.maps.DirectionsService());
+        const renderer = new google.maps.DirectionsRenderer({ map: map });
+        setDirectionsRenderer(renderer);
+        return () => {
+            renderer.setMap(null);
+        };
+    }, [routesLibrary, map]);
+
+    useEffect(() => {
+        if (!directionsService || !directionsRenderer || !source || !destination) {
+
+            if (directionsRenderer) {
+                directionsRenderer.setMap(null);
+            }
+            return;
+        }
+        const travelModeMap = {
+            driving: google.maps.TravelMode.DRIVING,
+            transit: google.maps.TravelMode.TRANSIT,
+            walking: google.maps.TravelMode.WALKING,
+            bicycling: google.maps.TravelMode.BICYCLING,
+        };
+
+        directionsService.route(
+            {
+                origin: { lat: source.lat, lng: source.lng },
+                destination: { lat: destination.lat, lng: destination.lng },
+                travelMode: travelModeMap[transportationMode],
+                provideRouteAlternatives: true,
+            },
+            (response, status) => {
+                if (status === "OK") {
+                    setDisplayedRoute(response);
+                    directionsRenderer.setDirections(response);
+                    directionsRenderer.setRouteIndex(selectedRouteIndex); // Set the selected route
+                } else {
+                    console.error("Directions request failed due to " + status);
+                    setDisplayedRoute(null);
+                }
+            }
+        );
+    }, [directionsService, directionsRenderer, source, destination, selectedRouteIndex, transportationMode]); // Add selectedRouteIndex as a dependency
+
+    return null;
+}
+
+export default RouteRenderer;

--- a/frontend/src/pages/Directions.tsx
+++ b/frontend/src/pages/Directions.tsx
@@ -9,6 +9,7 @@ import DirectionsBusIcon from '@mui/icons-material/DirectionsBus';
 import DirectionsWalkIcon from '@mui/icons-material/DirectionsWalk';
 import { LocationContext } from '../components/LocationContext';
 import { DirectionsBike } from '@mui/icons-material';
+import RouteRenderer from '../components/RouteRenderer';
 
 interface LocationType {
     name: string;
@@ -64,11 +65,11 @@ const Directions = () => {
                     })
                     .catch(error => console.error('Error fetching suggestions:', error));
             } else {
-                 if (activeField === "start") {
-                            setSourceResults([]);
-                        } else {
-                            setDestinationResults([]);
-                        }
+                if (activeField === "start") {
+                    setSourceResults([]);
+                } else {
+                    setDestinationResults([]);
+                }
             }
         }, DEBOUNCE_DELAY); // Use the environment variable here
     };
@@ -86,7 +87,7 @@ const Directions = () => {
 
 
 
-  useEffect(() => {
+    useEffect(() => {
         if (userLocation?.address && !sourceQuery && !isResettingStart && !isUserTyping) {
             setSourceQuery(userLocation.address);
             setSource(userLocation); // Set the source to userLocation
@@ -98,17 +99,17 @@ const Directions = () => {
 
 
     const handleSelect = async (index: number) => {
-      const place = (active === "start" ? sourceResults : destinationResults)[index];
-      const placeDetails = await getPlaceDetails(place.place_id);
+        const place = (active === "start" ? sourceResults : destinationResults)[index];
+        const placeDetails = await getPlaceDetails(place.place_id);
         isProgrammaticChange.current = true;
         if (active === "start") {
-             const s = document.getElementById("start-input") as HTMLInputElement;
+            const s = document.getElementById("start-input") as HTMLInputElement;
             s.value = (placeDetails as LocationType).name;
             setSourceQuery((placeDetails as LocationType).name);
             setSource(placeDetails as LocationType);
             setSourceResults([]);
         } else if (active === "end") {
-           setDestinationQuery((placeDetails as LocationType).name);
+            setDestinationQuery((placeDetails as LocationType).name);
             setDestination(placeDetails as LocationType);
             setDestinationResults([]);
         }
@@ -128,7 +129,7 @@ const Directions = () => {
     }, [transportationMode]);
 
 
-     const getDirections = async () => {
+    const getDirections = async () => {
         setRoutesAvailable(false);
         console.log("Getting Directions...");
         setTransportationMode("driving");
@@ -201,7 +202,7 @@ const Directions = () => {
         setDestinationQuery("");
         setDestination(undefined);
         setRoutesAvailable(false);
-          setDestinationResults([]);
+        setDestinationResults([]);
     }
 
     useEffect(() => {
@@ -230,7 +231,7 @@ const Directions = () => {
                             placeholder="Enter your starting location"
                             className="p-2 m-2 border-2 border-gray-200 rounded-lg w-full"
                             value={sourceQuery}
-                           onChange={(e) => {
+                            onChange={(e) => {
                                 setActive("start");
                                 setSourceQuery(e.target.value);
                                 setIsUserTyping(true); // Set typing to true
@@ -256,7 +257,7 @@ const Directions = () => {
                             placeholder="Enter your destination location"
                             className="p-2 m-2 border-2 border-gray-200 rounded-lg w-full"
                             value={destinationQuery}
-                           onChange={(e) => {
+                            onChange={(e) => {
                                 setActive("end");
                                 setDestinationQuery(e.target.value);
                                 setRoutes([]);
@@ -265,7 +266,7 @@ const Directions = () => {
                             }}
                             onKeyDown={handleKeyDown}
                         />
-                         {destinationQuery &&
+                        {destinationQuery &&
                             <button
                                 className="text-l font-bold text-gray-700 bg-white p-1"
                                 onClick={handleClearDestination}
@@ -275,7 +276,7 @@ const Directions = () => {
                         }
                     </div>
 
-                   {(active === "start" ? sourceResults : destinationResults).length > 0 && (
+                    {(active === "start" ? sourceResults : destinationResults).length > 0 && (
                         <div className="flex w-full">
                             <ul className="w-full" id="suggestions-container">
                                 {(active === "start" ? sourceResults : destinationResults).map((result, index) => (
@@ -300,7 +301,7 @@ const Directions = () => {
                         </div>
                     )}
 
-                      {(active === "start" ? sourceResults : destinationResults).length === 0 && (
+                    {(active === "start" ? sourceResults : destinationResults).length === 0 && (
                         <div id='directions-request-container' className="flex flex-col items-center w-full">
                             <button
                                 id="get-directions-button"
@@ -382,15 +383,15 @@ const Directions = () => {
                                                 </div>
                                             </div>
                                             <div className="selecting-route-button">
-                                            <button
-                                                className='bg-green-900 text-white font-bold'
-                                                onClick={() => {
-                                                    console.log("Selected Route: ", routes[index]);
-                                                    setSelectedRouteIndex(index); // Update selected route index
-                                                }}
-                                            >
-                                            Go
-                                        </button>
+                                                <button
+                                                    className='bg-green-900 text-white font-bold'
+                                                    onClick={() => {
+                                                        console.log("Selected Route: ", routes[index]);
+                                                        setSelectedRouteIndex(index); // Update selected route index
+                                                    }}
+                                                >
+                                                    Go
+                                                </button>
 
                                             </div>
                                         </div>
@@ -408,7 +409,7 @@ const Directions = () => {
                     <div id="map-container"
                         style={{ height: '86vh', width: '100vw' }}
                     >
-                      <MapWrapper source={source} destination={destination} selectedRouteIndex={selectedRouteIndex}  transportationMode={transportationMode}  />
+                        <MapWrapper source={source} destination={destination} selectedRouteIndex={selectedRouteIndex} transportationMode={transportationMode} />
                     </div>
                 </div>
             </div>
@@ -416,11 +417,11 @@ const Directions = () => {
     );
 }
 
-function MapWrapper({ source, destination, selectedRouteIndex, transportationMode }: { source: LocationType | undefined, destination: LocationType | undefined, selectedRouteIndex: number, transportationMode: "driving" | "transit" | "walking" | "bicycling"  }) {
+function MapWrapper({ source, destination, selectedRouteIndex, transportationMode }: { source: LocationType | undefined, destination: LocationType | undefined, selectedRouteIndex: number, transportationMode: "driving" | "transit" | "walking" | "bicycling" }) {
     const apiKey = import.meta.env.VITE_GOOGLE_MAPS_API_KEY;
     const [mapKey, setMapKey] = useState(Date.now());
 
-     useEffect(() => {
+    useEffect(() => {
         setMapKey(Date.now()); // Update the key
     }, [source, destination, selectedRouteIndex, transportationMode]); //include transportationMode
 
@@ -432,78 +433,19 @@ function MapWrapper({ source, destination, selectedRouteIndex, transportationMod
                 defaultCenter={{ lat: 45.4949, lng: -73.5779 }}
                 mapTypeControl={false}
                 fullscreenControl={false}
-             >
-            <RenderRoutes
-                key={`${source?.place_id}-${destination?.place_id}-${selectedRouteIndex}`}
-                source={source}
-                destination={destination}
-                selectedRouteIndex={selectedRouteIndex}
-                transportationMode = {transportationMode}
-            />
+            >
+                <RouteRenderer
+                    key={`${source?.place_id}-${destination?.place_id}-${selectedRouteIndex}`}
+                    source={source}
+                    destination={destination}
+                    selectedRouteIndex={selectedRouteIndex}
+                    transportationMode={transportationMode}
+                />
             </Map>
-         </APIProvider>
+        </APIProvider>
     );
 }
 
-function RenderRoutes({ source, destination, selectedRouteIndex, transportationMode }: {
-    source: LocationType | undefined;
-    destination: LocationType | undefined;
-    selectedRouteIndex: number;
-    transportationMode: "driving" | "transit" | "walking" | "bicycling";
 
-}) {
-    const map = useMap();
-    const routesLibrary = useMapsLibrary('routes');
-    const [directionsService, setDirectionsService] = useState<google.maps.DirectionsService>();
-    const [directionsRenderer, setDirectionsRenderer] = useState<google.maps.DirectionsRenderer>();
-    const [displayedRoute, setDisplayedRoute] = useState<google.maps.DirectionsResult | null>(null);
-
-     useEffect(() => {
-        if (!routesLibrary || !map) return;
-        setDirectionsService(new google.maps.DirectionsService());
-        const renderer = new google.maps.DirectionsRenderer({ map: map });
-        setDirectionsRenderer(renderer);
-        return () => {
-            renderer.setMap(null);
-        };
-    }, [routesLibrary, map]);
-
-    useEffect(() => {
-        if (!directionsService || !directionsRenderer || !source || !destination) {
-
-            if(directionsRenderer) {
-              directionsRenderer.setMap(null);
-            }
-            return;
-        }
-         const travelModeMap = {
-            driving: google.maps.TravelMode.DRIVING,
-            transit: google.maps.TravelMode.TRANSIT,
-            walking: google.maps.TravelMode.WALKING,
-            bicycling: google.maps.TravelMode.BICYCLING,
-        };
-
-        directionsService.route(
-            {
-                origin: { lat: source.lat, lng: source.lng },
-                destination: { lat: destination.lat, lng: destination.lng },
-                travelMode: travelModeMap[transportationMode],
-                provideRouteAlternatives: true,
-            },
-            (response, status) => {
-                if (status === "OK") {
-                    setDisplayedRoute(response);
-                   directionsRenderer.setDirections(response);
-                   directionsRenderer.setRouteIndex(selectedRouteIndex); // Set the selected route
-                } else {
-                    console.error("Directions request failed due to " + status);
-                    setDisplayedRoute(null);
-                }
-            }
-        );
-    }, [directionsService, directionsRenderer, source, destination, selectedRouteIndex, transportationMode]); // Add selectedRouteIndex as a dependency
-
-    return null;
-}
 
 export default Directions;

--- a/frontend/src/pages/Directions.tsx
+++ b/frontend/src/pages/Directions.tsx
@@ -174,7 +174,6 @@ const Directions = () => {
             console.log("Response from fetchDirections: ", response);
             setRoutes(response.driving);
             setDrivingRoutes(response.driving);
-            // console.log('transit: ', response.transit[0].legs[0].steps[1].transit_details);
             setTransitRoutes(response.transit);
             setWalkingRoutes(response.walking);
             setBicyclingRoutes(response.bicycling);

--- a/frontend/src/pages/Directions.tsx
+++ b/frontend/src/pages/Directions.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useRef, useEffect, useContext } from 'react';
-import { useLocation } from 'react-router-dom'; 
+import { useLocation } from 'react-router-dom';
 import MyLocationIcon from '@mui/icons-material/MyLocation';
 import RoomIcon from '@mui/icons-material/Room';
 import { getSuggestions, getPlaceDetails } from '../services/PlaceServices';
@@ -100,7 +100,7 @@ const Directions = () => {
     useEffect(() => {
         if (destinationFromState) {
             setDestinationQuery(destinationFromState); // Set destination query
-           // handleDebouncedSuggestions(destinationFromState, "end"); // Call debounced function
+            // handleDebouncedSuggestions(destinationFromState, "end"); // Call debounced function
 
             // Automatically selecst the first suggestion
             const selectFirstSuggestion = async () => {
@@ -140,7 +140,7 @@ const Directions = () => {
             setDestination(placeDetails as LocationType);
             setDestinationResults([]);
         }
-        setActive(""); 
+        setActive("");
         setSourceResults([]);
         setDestinationResults([]);
     };
@@ -155,6 +155,7 @@ const Directions = () => {
         } else if (transportationMode === "bicycling") {
             setRoutes(bicyclingRoutes);
         }
+        setSelectedRouteIndex(0); // Select the first route so that its displayed
     }, [transportationMode]);
 
 
@@ -172,11 +173,7 @@ const Directions = () => {
 
         const directionRequest = await fetchDirections(source!, destination!).then((response: any) => {
             console.log("Response from fetchDirections: ", response);
-
-
-
             setRoutes(response.driving);
-
             setDrivingRoutes(response.driving);
             setTransitRoutes(response.transit);
             setWalkingRoutes(response.walking);
@@ -193,13 +190,13 @@ const Directions = () => {
         setActive(""); // Reset active field
     };
 
-        // Ensure suggestions are hidden when the route is displayed
-    /*useEffect(() => {
-        if (routesAvailable) {
-            setSourceResults([]);
-            setDestinationResults([]);
-        }
-    }, [routesAvailable]);*/
+    // Ensure suggestions are hidden when the route is displayed
+    // useEffect(() => {
+    //     if (routesAvailable) {
+    //         setSourceResults([]);
+    //         setDestinationResults([]);
+    //     }
+    // }, [routesAvailable]);
 
 
     const handleTransportKeyDown = (event: React.KeyboardEvent<HTMLDivElement>) => {
@@ -222,6 +219,7 @@ const Directions = () => {
         setActive("");
         setSourceResults([]);
         setIsUserTyping(false); // Reset typing state
+        setSelectedRouteIndex(-1); // reset the selected route index so route is not displayed
 
         if (resetTimeoutRef.current) {
             clearTimeout(resetTimeoutRef.current);
@@ -238,10 +236,14 @@ const Directions = () => {
     };
 
     const handleClearDestination = () => {
+
         setDestinationQuery("");
         setDestination(undefined);
         setRoutesAvailable(false);
         setDestinationResults([]);
+        setSelectedRouteIndex(-1);// reset the selected route index so route is not displayed
+        setActive
+            ("");
     }
 
     useEffect(() => {
@@ -255,7 +257,7 @@ const Directions = () => {
         };
     }, []);
 
-    
+
 
 
     return (
@@ -315,7 +317,7 @@ const Directions = () => {
                         }
                     </div>
 
-                   {(active === "start" ? sourceResults : destinationResults)?.length > 0 && (
+                    {(active === "start" ? sourceResults : destinationResults)?.length > 0 && (
                         <div className="flex w-full">
                             <ul className="w-full" id="suggestions-container">
                                 {(active === "start" ? sourceResults : destinationResults)?.map((result, index) => (
@@ -340,7 +342,7 @@ const Directions = () => {
                         </div>
                     )}
 
-                      {(active === "start" ? sourceResults : destinationResults)?.length === 0 && (
+                    {(active === "start" ? sourceResults : destinationResults)?.length === 0 && (
                         <div id='directions-request-container' className="flex flex-col items-center w-full">
                             <button
                                 id="get-directions-button"
@@ -364,9 +366,11 @@ const Directions = () => {
                                     <DirectionsCarIcon
                                         style={{ color: transportationMode === "driving" ? "white" : "gray" }}
                                     />
-                                    <p id='driving-duration' className={`overflow-hidden text-ellipsis ml-1`} style={{ color: transportationMode === "driving" ? "white" : "gray" }} >
-                                        {drivingRoutes?.length > 0 ? drivingRoutes[0].legs[0].duration.text : " none "}
-                                    </p>
+                                    {transportationMode === "driving" &&
+                                        <p id='driving-duration' className={`overflow-hidden text-ellipsis ml-1`} style={{ color: transportationMode === "driving" ? "white" : "gray" }} >
+                                            {drivingRoutes?.length > 0 ? drivingRoutes[0].legs[0].duration.text : " none "}
+                                        </p>
+                                    }
                                 </button>
 
                                 <button id="transit-option"
@@ -375,9 +379,11 @@ const Directions = () => {
                                     <DirectionsBusIcon
                                         style={{ color: transportationMode === "transit" ? "white" : "gray" }}
                                     />
-                                    <p id='transit-duration' className={`overflow-hidden text-ellipsis ml-1`} style={{ color: transportationMode === "transit" ? "white" : "gray" }}>
-                                        {transitRoutes?.length > 0 ? transitRoutes[0].legs[0].duration.text : " none "}
-                                    </p>
+                                    {transportationMode === "transit" &&
+                                        <p id='transit-duration' className={`overflow-hidden text-ellipsis ml-1`} style={{ color: transportationMode === "transit" ? "white" : "gray" }}>
+                                            {transitRoutes?.length > 0 ? transitRoutes[0].legs[0].duration.text : " none "}
+                                        </p>
+                                    }
                                 </button>
                                 <button id="walking-option"
                                     onClick={() => setTransportationMode("walking")}
@@ -385,9 +391,11 @@ const Directions = () => {
                                     <DirectionsWalkIcon
                                         style={{ color: transportationMode === "walking" ? "white" : "gray" }}
                                     />
-                                    <p id='walking-duration' className={`overflow-hidden text-ellipsis ml-1`} style={{ color: transportationMode === "walking" ? "white" : "gray" }} >
-                                        {walkingRoutes?.length > 0 ? walkingRoutes[0].legs[0].duration.text : " none "}
-                                    </p>
+                                    {transportationMode === "walking" &&
+                                        <p id='walking-duration' className={`overflow-hidden text-ellipsis ml-1`} style={{ color: transportationMode === "walking" ? "white" : "gray" }} >
+                                            {walkingRoutes?.length > 0 ? walkingRoutes[0].legs[0].duration.text : " none "}
+                                        </p>
+                                    }
                                 </button>
                                 <button id="bicycling-option"
                                     onClick={() => setTransportationMode("bicycling")}
@@ -396,9 +404,11 @@ const Directions = () => {
                                     <DirectionsBike
                                         style={{ color: transportationMode === "bicycling" ? "white" : "gray" }}
                                     />
-                                    <p id='bicycling-duration' className={`overflow-hidden text-ellipsis ml-1`} style={{ color: transportationMode === "bicycling" ? "white" : "gray" }} >
-                                        {bicyclingRoutes?.length > 0 ? bicyclingRoutes[0].legs[0].duration.text : "-"}
-                                    </p>
+                                    {transportationMode === "bicycling" &&
+                                        <p id='bicycling-duration' className={`overflow-hidden text-ellipsis ml-1`} style={{ color: transportationMode === "bicycling" ? "white" : "gray" }} >
+                                            {bicyclingRoutes?.length > 0 ? bicyclingRoutes[0].legs[0].duration.text : "-"}
+                                        </p>
+                                    }
                                 </button>
 
 
@@ -408,26 +418,27 @@ const Directions = () => {
                                     route.legs ? (
                                         <div key={index}
                                             tabIndex={0}
-                                            onKeyDown={(e) => (e.key === "Enter" || e.key === " ") && console.log("Selected Route: ", routes[index])}
+                                            onKeyDown={(e) => (e.key === "Enter" || e.key === " ") && console.log("Selected Route", index, ":",routes[index])}
                                             id="route-item-container"
                                             className="flex flex-row border-2 border-gray-200 rounded-lg w-full  mt-2 p-2 justify-between  align-middle shadow-sm"
 
                                         >
-                                            <div id='route-item-duration-distance' className="flex flex-col items-start align-middle">
+                                            <button id='route-item-duration-distance ' className="flex flex-col items-start align-middle focus:outline-none bg-white w-full"
+                                                onClick={() => {
+                                                    console.log("Selected Route ", index, ":",
+                                                         routes[index]);
+                                                    setSelectedRouteIndex(index); // Update selected route index
+                                                }}>
                                                 <span className="font-bold text-lg">{route.legs[0].duration.text}</span>
                                                 <div className="flex">
                                                     <span className="text-xs">{route.legs[0].distance.text}</span>
                                                     {index === 0 && <span className="text-xs ml-1">— Fastest Route</span>}
                                                     {transportationMode === "transit" && <span className="text-xs ml-1">— {route.legs[0].steps.length} stops</span>}
                                                 </div>
-                                            </div>
-                                            <div className="selecting-route-button">
+                                            </button>
+                                            <div id="selecting-route-button" className='flex flex-col justify-center'>
                                                 <button
-                                                    className='bg-green-900 text-white font-bold'
-                                                    onClick={() => {
-                                                        console.log("Selected Route: ", routes[index]);
-                                                        setSelectedRouteIndex(index); // Update selected route index
-                                                    }}
+                                                    className='bg-green-900 text-white font-bold focus:outline-none'
                                                 >
                                                     Go
                                                 </button>
@@ -473,15 +484,15 @@ function MapWrapper({ source, destination, selectedRouteIndex, transportationMod
                 mapTypeControl={false}
                 fullscreenControl={false}
             >
-            { selectedRouteIndex !== -1 &&
-                <RouteRenderer
-                    key={`${source?.place_id}-${destination?.place_id}-${selectedRouteIndex}`}
-                    source={source}
-                    destination={destination}
-                    selectedRouteIndex={selectedRouteIndex}
-                    transportationMode={transportationMode}
-                />
-            }
+                {selectedRouteIndex !== -1 &&
+                    <RouteRenderer
+                        key={`${source?.place_id}-${destination?.place_id}-${selectedRouteIndex}`}
+                        source={source}
+                        destination={destination}
+                        selectedRouteIndex={selectedRouteIndex}
+                        transportationMode={transportationMode}
+                    />
+                }
             </Map>
         </APIProvider>
     );

--- a/frontend/src/pages/Directions.tsx
+++ b/frontend/src/pages/Directions.tsx
@@ -89,7 +89,6 @@ const Directions = () => {
     };
 
 
-
     useEffect(() => {
         if (userLocation?.address && !sourceQuery && !isResettingStart && !isUserTyping) {
             setSourceQuery(userLocation.address);
@@ -175,6 +174,7 @@ const Directions = () => {
             console.log("Response from fetchDirections: ", response);
             setRoutes(response.driving);
             setDrivingRoutes(response.driving);
+            console.log('transit: ', response.transit[0].legs[0].steps[1].transit_details);
             setTransitRoutes(response.transit);
             setWalkingRoutes(response.walking);
             setBicyclingRoutes(response.bicycling);
@@ -242,8 +242,7 @@ const Directions = () => {
         setRoutesAvailable(false);
         setDestinationResults([]);
         setSelectedRouteIndex(-1);// reset the selected route index so route is not displayed
-        setActive
-            ("");
+        setActive("");
     }
 
     useEffect(() => {
@@ -418,22 +417,46 @@ const Directions = () => {
                                     route.legs ? (
                                         <div key={index}
                                             tabIndex={0}
-                                            onKeyDown={(e) => (e.key === "Enter" || e.key === " ") && console.log("Selected Route", index, ":",routes[index])}
+                                            onKeyDown={(e) => (e.key === "Enter" || e.key === " ") && console.log("Selected Route", index, ":", routes[index])}
                                             id="route-item-container"
-                                            className="flex flex-row border-2 border-gray-200 rounded-lg w-full  mt-2 p-2 justify-between  align-middle shadow-sm"
-
+                                            className="flex flex-row border-2 border-gray-200 rounded-lg w-full  mt-2 p-2 justify-between focus:outline-none bg-white  align-middle shadow-sm"
                                         >
-                                            <button id='route-item-duration-distance ' className="flex flex-col items-start align-middle focus:outline-none bg-white w-full"
+                                            <button id='route-item-duration-distance '
+                                                className="flex flex-col items-start align-middle  bg-white w-full"
                                                 onClick={() => {
                                                     console.log("Selected Route ", index, ":",
-                                                         routes[index]);
+                                                        routes[index]);
                                                     setSelectedRouteIndex(index); // Update selected route index
-                                                }}>
+                                                }}
+                                            >
                                                 <span className="font-bold text-lg">{route.legs[0].duration.text}</span>
-                                                <div className="flex">
-                                                    <span className="text-xs">{route.legs[0].distance.text}</span>
-                                                    {index === 0 && <span className="text-xs ml-1">— Fastest Route</span>}
-                                                    {transportationMode === "transit" && <span className="text-xs ml-1">— {route.legs[0].steps.length} stops</span>}
+                                                {transportationMode !== "transit" &&
+                                                    <div className="flex">
+                                                        <span className="text-xs">{route.legs[0].distance.text}</span>
+                                                        {index === 0 && <span className="text-xs ml-1">— Fastest Route</span>}
+                                                    </div>
+                                                }
+                                                <div className="flex flex-wrap w-full">
+                                                    {transportationMode === "transit" &&
+                                                        <>
+                                                            {route.legs[0].steps?.map((step: any, index: number) => (
+                                                                // 
+                                                                <React.Fragment key={index}>
+                                                                    {step.travel_mode === "WALKING" && <span className="flex items-center text-xs ml-1">
+                                                                        <DirectionsWalkIcon
+                                                                            style={{ color: "gray", fontSize: "0.8rem" }}
+                                                                        />
+                                                                        {step.duration.text}
+                                                                        </span>}
+                                                                    {step.transit_details && <span className="text-xs ml-1 rounded-lg pl-1 pr-1"
+                                                                        style={{ backgroundColor: step.transit_details.line.color, color: "white" }}>{step.transit_details.line.short_name}</span>}
+                                                                    {index !== route.legs[0].steps.length - 1 && <span className="text-xs ml-1">{'>'}</span>}
+
+                                                                </React.Fragment>
+                                                                // )
+                                                            ))}
+                                                        </>
+                                                    }
                                                 </div>
                                             </button>
                                             <div id="selecting-route-button" className='flex flex-col justify-center'>

--- a/frontend/src/pages/Directions.tsx
+++ b/frontend/src/pages/Directions.tsx
@@ -44,6 +44,7 @@ const Directions = () => {
     const [selectedResultIndex, setSelectedResultIndex] = useState<number>(-1);
     const isProgrammaticChange = useRef(false);
     const [selectedRouteIndex, setSelectedRouteIndex] = useState<number>(-1);
+    const [selectedRoute, setSelectedRoute] = useState<any>();
     // Debounce ref
     const debounceRef = useRef<NodeJS.Timeout | null>(null);
     // Get debounce delay from environment variable, default to 300ms
@@ -154,7 +155,6 @@ const Directions = () => {
         } else if (transportationMode === "bicycling") {
             setRoutes(bicyclingRoutes);
         }
-        setSelectedRouteIndex(0); // Select the first route so that its displayed
     }, [transportationMode]);
 
 
@@ -188,6 +188,7 @@ const Directions = () => {
         setSourceResults([]); // Clear the source results
         setDestinationResults([]); // Clear the destination results
         setActive(""); // Reset active field
+        setSelectedRouteIndex(0); // Select the first route so that its displayed
     };
 
     // Ensure suggestions are hidden when the route is displayed
@@ -256,6 +257,24 @@ const Directions = () => {
         };
     }, []);
 
+    const handleSelectedRoute = (index: number) => {
+        //get the active transportation typpe
+        if (transportationMode === "driving") {
+            setSelectedRoute(drivingRoutes[index]);
+        } else if (transportationMode === "transit") {
+            setSelectedRoute(transitRoutes[index]);
+        }
+        else if (transportationMode === "walking") {
+            setSelectedRoute(walkingRoutes[index]);
+        }
+        else if (transportationMode === "bicycling") {
+            setSelectedRoute(bicyclingRoutes[index]);
+        }
+        console.log("Selected Route: ", selectedRoute  , 'from ', transportationMode);
+        setRoutesAvailable(false);
+
+    }
+
 
 
 
@@ -263,7 +282,8 @@ const Directions = () => {
         <APIProvider apiKey={import.meta.env.VITE_GOOGLE_MAPS_API_KEY} libraries={["places", "geometry"]}>
             <div className="relative flex flex-col flex-shrink-0 w-full" >
                 <div className=" fixed flex flex-col flex-shrink-0 w-full top-55 bg-white z-30">
-                    <div className="flex flex-row items-center pl-2 pr-2">
+                    <div id="input-start-container"
+                        className="flex flex-row items-center pl-2 pr-2">
                         <MyLocationIcon />
                         <input
                             id="start-input"
@@ -289,7 +309,8 @@ const Directions = () => {
                             </button>
                         }
                     </div>
-                    <div className="flex flex-row items-center pl-2 pr-2">
+                    <div id="input-end-container"
+                        className="flex flex-row items-center pl-2 pr-2">
                         <RoomIcon style={{ color: "red" }} />
                         <input
                             id="end-input"
@@ -447,7 +468,7 @@ const Directions = () => {
                                                                             style={{ color: "gray", fontSize: "0.8rem" }}
                                                                         />
                                                                         {step.duration.text}
-                                                                        </span>}
+                                                                    </span>}
                                                                     {step.transit_details && <span className="text-xs ml-1 rounded-lg pl-1 pr-1"
                                                                         style={{ backgroundColor: step.transit_details.line.color, color: "white" }}>{step.transit_details.line.short_name}</span>}
                                                                     {index !== route.legs[0].steps.length - 1 && <span className="text-xs ml-1">{'>'}</span>}
@@ -462,6 +483,7 @@ const Directions = () => {
                                             <div id="selecting-route-button" className='flex flex-col justify-center'>
                                                 <button
                                                     className='bg-green-900 text-white font-bold focus:outline-none'
+                                                    onClick={() => handleSelectedRoute(index)}
                                                 >
                                                     Go
                                                 </button>

--- a/frontend/src/pages/Directions.tsx
+++ b/frontend/src/pages/Directions.tsx
@@ -4,7 +4,7 @@ import MyLocationIcon from '@mui/icons-material/MyLocation';
 import RoomIcon from '@mui/icons-material/Room';
 import { getSuggestions, getPlaceDetails } from '../services/PlaceServices';
 import { fetchDirections } from '../services/directionsServices';
-import { APIProvider, Map, useMap, useMapsLibrary } from '@vis.gl/react-google-maps';
+import { APIProvider, Map } from '@vis.gl/react-google-maps';
 import DirectionsCarIcon from '@mui/icons-material/DirectionsCar';
 import DirectionsBusIcon from '@mui/icons-material/DirectionsBus';
 import DirectionsWalkIcon from '@mui/icons-material/DirectionsWalk';

--- a/frontend/src/pages/Directions.tsx
+++ b/frontend/src/pages/Directions.tsx
@@ -40,7 +40,7 @@ const Directions = () => {
     const resetTimeoutRef = useRef<NodeJS.Timeout | null>(null);
     const [selectedResultIndex, setSelectedResultIndex] = useState<number>(-1);
     const isProgrammaticChange = useRef(false);
-
+    const [selectedRouteIndex, setSelectedRouteIndex] = useState<number>(-1);
     // Debounce ref
     const debounceRef = useRef<NodeJS.Timeout | null>(null);
     // Get debounce delay from environment variable, default to 300ms
@@ -162,7 +162,6 @@ const Directions = () => {
     };
 
 
-
     const handleTransportKeyDown = (event: React.KeyboardEvent<HTMLDivElement>) => {
         if (event.key === "ArrowRight") {
             setTransportationMode((prev) =>
@@ -216,7 +215,7 @@ const Directions = () => {
         };
     }, []);
 
-    const [selectedRouteIndex, setSelectedRouteIndex] = useState<number>(0);
+    
 
 
     return (
@@ -434,6 +433,7 @@ function MapWrapper({ source, destination, selectedRouteIndex, transportationMod
                 mapTypeControl={false}
                 fullscreenControl={false}
             >
+            { selectedRouteIndex !== -1 &&
                 <RouteRenderer
                     key={`${source?.place_id}-${destination?.place_id}-${selectedRouteIndex}`}
                     source={source}
@@ -441,6 +441,7 @@ function MapWrapper({ source, destination, selectedRouteIndex, transportationMod
                     selectedRouteIndex={selectedRouteIndex}
                     transportationMode={transportationMode}
                 />
+            }
             </Map>
         </APIProvider>
     );

--- a/frontend/src/pages/Directions.tsx
+++ b/frontend/src/pages/Directions.tsx
@@ -174,7 +174,7 @@ const Directions = () => {
             console.log("Response from fetchDirections: ", response);
             setRoutes(response.driving);
             setDrivingRoutes(response.driving);
-            console.log('transit: ', response.transit[0].legs[0].steps[1].transit_details);
+            // console.log('transit: ', response.transit[0].legs[0].steps[1].transit_details);
             setTransitRoutes(response.transit);
             setWalkingRoutes(response.walking);
             setBicyclingRoutes(response.bicycling);
@@ -496,6 +496,10 @@ const Directions = () => {
                                         </p>
                                     )
                                 ))}
+
+                                {routes?.length === 0 &&
+                                    <p className=" flex items-center justify-center pt-3">No {transportationMode} routes  available</p>
+                                }
 
                             </div>
                         </div>

--- a/frontend/src/pages/Directions.tsx
+++ b/frontend/src/pages/Directions.tsx
@@ -461,7 +461,7 @@ const Directions = () => {
                                                         <>
                                                             {route.legs[0].steps?.map((step: any, index: number) => (
                                                                 // 
-                                                                <React.Fragment key={index}>
+                                                                <React.Fragment key={0}>
                                                                     {step.travel_mode === "WALKING" && <span className="flex items-center text-xs ml-1">
                                                                         <DirectionsWalkIcon
                                                                             style={{ color: "gray", fontSize: "0.8rem" }}


### PR DESCRIPTION

## Title
Pull request fixes the bug where the routes are displayed on the map before the user has selected one and other minor changes.

## Type of Changes
- [ ] New feature
- [x] Bug fix 
- [ ] CI/CD Update
- [x] UI/UX Improvement 
- [x] Refactoring 

## Description 
- refactoring code related to the render of directions on the map in its own file for better maintainability. (see file: '/components/RouteRenderer.tsx') 
- changed the display of info in transit routes tab  to show which lines the routes use
<img width="367" alt="image" src="https://github.com/user-attachments/assets/15eaff5b-3558-4d2f-afa9-92b068d87eed" />

- after clicking on 'Go' the route options are hidden so we only see the map 
![Untitled design-5](https://github.com/user-attachments/assets/d1a10d14-dfb1-4490-9049-3626bc8be43a)

## Description of the bug
bug description was in issue #125 

## describe the resolved behaviour
Now the route is shown only after clicking on 'Get Directions'
![Untitled design-6](https://github.com/user-attachments/assets/35502b6b-4961-44c9-9eb5-7b224bd42a0b)


<i> <b>  
closes #125
</b> </i>

## Added tests ?

- [ ] ✅ Yes.
- [x] ❌ No cause they aren't necessary.

## Checklist 

- [x] I have commented my code.
- [x] I have performed a self-review of my code

