### PR TITLE
test: add auth e2e tests and fix validation message mismatch across environments

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -14,6 +14,7 @@
         "@oslojs/crypto": "^1.0.1",
         "@oslojs/encoding": "^1.1.0",
         "@types/google.maps": "^3.58.1",
+        "axios": "^1.8.4",
         "axios-mock-adapter": "^2.1.0",
         "body-parser": "^1.20.3",
         "cookie-parser": "^1.4.7",
@@ -3811,9 +3812,9 @@
       "license": "MIT"
     },
     "node_modules/axios": {
-      "version": "1.8.1",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.8.1.tgz",
-      "integrity": "sha512-NN+fvwH/kV01dYUQ3PTOZns4LWtWhOFCAhQ/pHb88WQ1hNe5V/dvFwc4VJcDL11LT9xSX0QtsR8sWUuyOuOq7g==",
+      "version": "1.8.4",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.8.4.tgz",
+      "integrity": "sha512-eBSYY4Y68NNlHbHBMdeDmKNtDgXWhQsJcGqzO3iLUM0GraQFSS9cVgPX5I9b3lbdFKyYoAEGAZF1DwhTaljNAw==",
       "license": "MIT",
       "dependencies": {
         "follow-redirects": "^1.15.6",

--- a/backend/package.json
+++ b/backend/package.json
@@ -19,6 +19,7 @@
     "@oslojs/crypto": "^1.0.1",
     "@oslojs/encoding": "^1.1.0",
     "@types/google.maps": "^3.58.1",
+    "axios": "^1.8.4",
     "axios-mock-adapter": "^2.1.0",
     "body-parser": "^1.20.3",
     "cookie-parser": "^1.4.7",

--- a/cypress/e2e/auth.cy.js
+++ b/cypress/e2e/auth.cy.js
@@ -1,6 +1,5 @@
 describe("Authentication Tests", () => {
     beforeEach(() => {
-        // Mock authentication API response
         cy.intercept("GET", "/api/auth/me", {
             statusCode: 200,
             body: { user: { id: "test-user", email: "test@example.com" } }, // Fake authenticated user
@@ -13,7 +12,6 @@ describe("Authentication Tests", () => {
 
         cy.visit("http://localhost:5173/login");
 
-        // Ensure page is loaded before interacting
         cy.get("body").should("be.visible");
         cy.wait("@getCurrentUser");  // Wait for auth check
     });
@@ -23,10 +21,8 @@ describe("Authentication Tests", () => {
         cy.get("#password").should("exist").click().type("password123");
         cy.get("button[type=submit]").should("exist").click();
 
-        // Wait for login request
         cy.wait("@loginRequest");
 
-        // Simulate session token being set
         cy.setCookie("session", "fake-session-token");
 
         cy.url().should("include", "/"); // Ensure redirection works
@@ -35,10 +31,10 @@ describe("Authentication Tests", () => {
 
     it("Prevents login when fields are empty", () => {
         cy.get("button[type=submit]").click();
-    
-        // Check if the browser displays validation error (native HTML behavior)
-        cy.get("#email").then(($input) => {
-            expect($input[0].validationMessage).to.eq("Please fill in this field.");
-        });
+      
+        cy.get("#email")
+          .invoke("prop", "validationMessage")
+          .should("match", /fill (in|out) this field/i); // Matches both variants
+      
     });
 });

--- a/cypress/e2e/auth.cy.js
+++ b/cypress/e2e/auth.cy.js
@@ -1,0 +1,44 @@
+describe("Authentication Tests", () => {
+    beforeEach(() => {
+        // Mock authentication API response
+        cy.intercept("GET", "/api/auth/me", {
+            statusCode: 200,
+            body: { user: { id: "test-user", email: "test@example.com" } }, // Fake authenticated user
+        }).as("getCurrentUser");
+
+        cy.intercept("POST", "/api/auth/login", {
+            statusCode: 200,
+            body: { token: "fake-session-token" },
+        }).as("loginRequest");
+
+        cy.visit("http://localhost:5173/login");
+
+        // Ensure page is loaded before interacting
+        cy.get("body").should("be.visible");
+        cy.wait("@getCurrentUser");  // Wait for auth check
+    });
+
+    it("Logs in successfully with valid credentials", () => {
+        cy.get("#email").should("exist").click().type("testuser@example.com");
+        cy.get("#password").should("exist").click().type("password123");
+        cy.get("button[type=submit]").should("exist").click();
+
+        // Wait for login request
+        cy.wait("@loginRequest");
+
+        // Simulate session token being set
+        cy.setCookie("session", "fake-session-token");
+
+        cy.url().should("include", "/"); // Ensure redirection works
+    });
+
+
+    it("Prevents login when fields are empty", () => {
+        cy.get("button[type=submit]").click();
+    
+        // Check if the browser displays validation error (native HTML behavior)
+        cy.get("#email").then(($input) => {
+            expect($input[0].validationMessage).to.eq("Please fill in this field.");
+        });
+    });
+});

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -24,7 +24,8 @@
         "@testing-library/user-event": "^14.6.1",
         "@turf/turf": "^7.2.0",
         "@types/js-cookie": "^3.0.6",
-        "axios": "^1.8.1",
+        "axios": "^1.8.4",
+        "axios-mock-adapter": "^2.1.0",
         "date-fns": "^4.1.0",
         "dayjs": "^1.11.13",
         "framer-motion": "^12.4.7",
@@ -33,7 +34,7 @@
         "js-cookie": "^3.0.5",
         "lucide-react": "^0.475.0",
         "react-calendar": "^5.1.0",
-        "react-icons": "^5.4.0",
+        "react-icons": "^5.5.0",
         "react-router-dom": "^7.2.0",
         "typescript-toastify": "^1.0.4"
       },
@@ -5526,14 +5527,27 @@
       "license": "MIT"
     },
     "node_modules/axios": {
-      "version": "1.8.1",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.8.1.tgz",
-      "integrity": "sha512-NN+fvwH/kV01dYUQ3PTOZns4LWtWhOFCAhQ/pHb88WQ1hNe5V/dvFwc4VJcDL11LT9xSX0QtsR8sWUuyOuOq7g==",
+      "version": "1.8.4",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.8.4.tgz",
+      "integrity": "sha512-eBSYY4Y68NNlHbHBMdeDmKNtDgXWhQsJcGqzO3iLUM0GraQFSS9cVgPX5I9b3lbdFKyYoAEGAZF1DwhTaljNAw==",
       "license": "MIT",
       "dependencies": {
         "follow-redirects": "^1.15.6",
         "form-data": "^4.0.0",
         "proxy-from-env": "^1.1.0"
+      }
+    },
+    "node_modules/axios-mock-adapter": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/axios-mock-adapter/-/axios-mock-adapter-2.1.0.tgz",
+      "integrity": "sha512-AZUe4OjECGCNNssH8SOdtneiQELsqTsat3SQQCWLPjN436/H+L9AjWfV7bF+Zg/YL9cgbhrz5671hoh+Tbn98w==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "is-buffer": "^2.0.5"
+      },
+      "peerDependencies": {
+        "axios": ">= 0.17.0"
       }
     },
     "node_modules/babel-plugin-macros": {
@@ -7884,6 +7898,29 @@
         "node": ">=8"
       }
     },
+    "node_modules/is-buffer": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.5.tgz",
+      "integrity": "sha512-i2R6zNFDwgEHJyQUtJEk0XFi1i0dPFn/oqjK3/vPCcDeJvW5NQ83V8QbicfF1SupOaB0h8ntgBC2YiE7dfyctQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/is-core-module": {
       "version": "2.16.1",
       "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.16.1.tgz",
@@ -9832,9 +9869,9 @@
       }
     },
     "node_modules/react-icons": {
-      "version": "5.4.0",
-      "resolved": "https://registry.npmjs.org/react-icons/-/react-icons-5.4.0.tgz",
-      "integrity": "sha512-7eltJxgVt7X64oHh6wSWNwwbKTCtMfK35hcjvJS0yxEAhPM8oUKdS3+kqaW1vicIltw+kR2unHaa12S9pPALoQ==",
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/react-icons/-/react-icons-5.5.0.tgz",
+      "integrity": "sha512-MEFcXdkP3dLo8uumGI5xN3lDFNsRtrjbOEKDLD7yv76v4wpnEq2Lt2qeHaQOr34I/wPN3s3+N08WkQ+CW37Xiw==",
       "license": "MIT",
       "peerDependencies": {
         "react": "*"

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -56,7 +56,8 @@
     "@testing-library/user-event": "^14.6.1",
     "@turf/turf": "^7.2.0",
     "@types/js-cookie": "^3.0.6",
-    "axios": "^1.8.1",
+    "axios": "^1.8.4",
+    "axios-mock-adapter": "^2.1.0",
     "date-fns": "^4.1.0",
     "dayjs": "^1.11.13",
     "framer-motion": "^12.4.7",
@@ -65,7 +66,7 @@
     "js-cookie": "^3.0.5",
     "lucide-react": "^0.475.0",
     "react-calendar": "^5.1.0",
-    "react-icons": "^5.4.0",
+    "react-icons": "^5.5.0",
     "react-router-dom": "^7.2.0",
     "typescript-toastify": "^1.0.4"
   }


### PR DESCRIPTION
Introduced two authentication-related Cypress end-to-end tests:
✅ Logs in successfully with valid credentials
✅ Prevents login when fields are empty

Note: The second test previously failed in GitHub Actions due to inconsistent native validation messages across environments ("fill in" vs. "fill out"). This has been resolved by using a regex-based assertion to accommodate both message variants.