### PR TITLE
[FIX] correct positioning and styling of message component

### DIFF
--- a/frontend/src/components/UserLocation.tsx
+++ b/frontend/src/components/UserLocation.tsx
@@ -165,7 +165,7 @@ function UserLocation() {
 
 function Message({ message }: Readonly<{ message: string }>) {
   return (
-    <div id="message" className="fixed flex justify-center self-center bottom-14 m-2 transform -translate-x-1/2 bg-blue-500  text-black px-4 py-2 rounded-md shadow-md transition-opacity duration-500 z-10">
+    <div id="message" className="fixed flex justify-center self-center bottom-14 m-2 transform -translate-x-2 bg-blue-500  text-black px-4 py-2 rounded-md shadow-md transition-opacity duration-500 z-10">
         <p className="align-middle">
           {message}
         </p>


### PR DESCRIPTION
## Title
Correct Message Display

## Type of Changes
- [ ] New feature
- [x] Bug fix 
- [ ] CI/CD Update
- [x] UI/UX Improvement 
- [ ] Refactoring 

## Description 
Now the message after answering the modal is correctly positioned and the user can see it and read it.

<img width="311" alt="Screen Shot 2025-04-03 at 10 41 41 PM" src="https://github.com/user-attachments/assets/02647a5e-65cc-4183-a99f-4351a056a26f" />


## Description of the bug
The message was half appearing which makes it impossible to users to read it.


## describe the resolved behaviour
The message is fully displayed to users.


<i> <b>  
closes #182 
</b> </i>


## Additional Information
none.

## Added tests ?

- [ ] ✅ Yes.
- [x] ❌ No cause they aren't necessary.

## Checklist 

- [x] I have commented my code.
- [x] I have performed a self-review of my code