### PR TITLE
[update] change of default directions page

### DIFF
--- a/cypress/e2e/BottomNavBar.cy.js
+++ b/cypress/e2e/BottomNavBar.cy.js
@@ -24,7 +24,7 @@ describe("Bottom Navigation Bar", () => {
         const navItems = [
             { label: "Shuttle", path: "/shuttle" },
             { label: "Map", path: "/map" },
-            { label: "Directions", path: "/indoordirections" },
+            { label: "Directions", path: "/directions" },
             { label: "Schedule", path: "/schedule" },
         ];
 

--- a/frontend/src/components/BottomNavBar.tsx
+++ b/frontend/src/components/BottomNavBar.tsx
@@ -54,7 +54,7 @@ const BottomNavBar = () => {
 
 
   // Handle direction type selection
-  const handleDirectionTypeChange = (type: 'indoor' | 'outdoor') => {
+  const handleDirectionTypeChange = (type: 'outdoor' | 'indoor') => {
     setDirectionType(type);
 
     // Use a more robust state management approach
@@ -144,7 +144,7 @@ const BottomNavBar = () => {
         <NavButton
           icon={Navigation}
           label={directionLabel}
-          value="/indoordirections"
+          value="/directions"
           isActive={isDirectionsActive}
 
 

--- a/frontend/src/components/BottomNavBar.tsx
+++ b/frontend/src/components/BottomNavBar.tsx
@@ -6,7 +6,7 @@ const BottomNavBar = () => {
   const navigate = useNavigate();
   const location = useLocation();
   const [showDirectionOptions, setShowDirectionOptions] = useState(false);
-  const [directionType, setDirectionType] = useState<'indoor' | 'outdoor'>('indoor');
+  const [directionType, setDirectionType] = useState<'indoor' | 'outdoor'>('outdoor');
 
   // Close menus when clicking outside
   useEffect(() => {
@@ -54,7 +54,7 @@ const BottomNavBar = () => {
 
 
   // Handle direction type selection
-  const handleDirectionTypeChange = (type: 'outdoor' | 'indoor') => {
+  const handleDirectionTypeChange = (type: 'indoor' | 'outdoor') => {
     setDirectionType(type);
 
     // Use a more robust state management approach


### PR DESCRIPTION
## Title
Change of default directions page to get outdoors directions first. 

## Type of Changes
- [ ] New feature
- [ ] Bug fix 
- [ ] CI/CD Update
- [x] UI/UX Improvement 
- [ ] Refactoring 

## Description 
This change is based on the usability testing that was performed with Clarity in which we noted a lot of interactions in the nav bar to switch to outdoor directions first. The user now starts with the outdoor directions and can switch to indoors in the same way as before. 

![demo](https://github.com/user-attachments/assets/9a4efa3a-a63a-4b53-b9de-1189521c057e)


<i> <b> closes #126 
</b> </i>
