### PR TITLE
Fix the bug about additional information of building

### DIFF
--- a/frontend/src/components/MapComponent.tsx
+++ b/frontend/src/components/MapComponent.tsx
@@ -45,39 +45,6 @@ function MapComponent({ geoJsonData, setIsUserInsideBuilding }: MapComponentProp
         }
       }
     });
-    const infoWindow = new google.maps.InfoWindow();
-    const listener = map.data.addListener("click", (event: google.maps.Data.MouseEvent) => {
-      const name = event.feature.getProperty("name");
-      const Address = event.feature.getProperty("address")
-      const content = `
-        <div style="
-      max-width: 250px;
-      background-color: #FFFFFF;
-      border-radius: 8px;
-      padding: 12px;
-      box-shadow: 0 2px 6px rgba(0,0,0,0.3);
-      color: #333;
-      font-family: 'Roboto', sans-serif;
-    ">
-      <h3 style="
-        margin: 0 0 8px 0;
-        font-size: 16px;
-        color: #5A2DA2; /* Purple accent color */
-      ">
-        ${name}
-      </h3>
-      <p style="margin: 0; font-size: 14px;">
-        ${Address}
-      </p>
-    </div>
-      `;
-      infoWindow.setContent(content);
-      infoWindow.setPosition(event.latLng);
-      infoWindow.open(map)});
-      
-      return () => {
-        google.maps.event.removeListener(listener);
-      };
     }, [map, geoJsonData, userLocation, setIsUserInsideBuilding]);
 
   return null;


### PR DESCRIPTION
## Title
Additional information of buildings only appears when clicking building marker.

## Type of Changes
- [ ] New feature
- [x] Bug fix 
- [ ] CI/CD Update
- [ ] UI/UX Improvement 
- [x] Refactoring 

## Description 
The additional information of buildings appeared by clicking anywhere on the highlighted are of a building before. Now it only appears when clicking the marker of a building.


![Screenshot 2025-03-26 at 3 05 59 AM](https://github.com/user-attachments/assets/ee5ce0b2-fd04-454d-839d-14a0d66cd33a)


<i> <b> Related issues #172   
closes #172  
</b> </i>

## Added tests ?

- [ ] ✅ Yes.
- [x] ❌ No cause they aren't necessary.

## Checklist 

- [x] I have commented my code.
- [x] I have performed a self-review of my code